### PR TITLE
Updated Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ homepage: https://github.com/qiao/javascript-playground
 
 ### Project List ###
 
-1. [Visual Befunge93 Interpreter](http://qiao.github.com/javascript-playground/befunge93/)
+1. [Visual Befunge93 Interpreter](https://qiao.github.io/javascript-playground/visual-befunge93-interpreter/)
 
     Visual Befunge93 interpreter using HTML5 canvas. This is my first attempt on Javascript, so the code is a bit messy.
 
-2. [WebGL Tree](http://qiao.github.com/javascript-playground/webgl-tree/)
+2. [WebGL Tree](https://qiao.github.io/javascript-playground/webgl-tree/)
 
     A simple demo using the awesome [Three.js](https://github.com/mrdoob/three.js) to generate a tree by recursion. 
 
-3. [Vigenere Cipher](http://qiao.github.com/javascript-playground/vigenere-cipher/)
+3. [Vigenere Cipher](https://qiao.github.io/javascript-playground/vigenere-cipher/)
 
     A demo of cracking Vigenere cipher. This is my homework for Cryptography and Network Security.


### PR DESCRIPTION
GitHub change the way they host websites. they now always have https and also use io at the end. Also the befunge folder name was incorrect. this change should fix the links.